### PR TITLE
ブログ投稿の削除機能実装

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -42,4 +42,10 @@ class PostController extends Controller
         $post->fill($input_post)->save();
         return redirect('/posts/' . $post->id);
     }
+    
+    public function delete(Post $post)
+    {
+        $post->delete();
+        return redirect('/');
+    }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -4,10 +4,12 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Post extends Model
 {
     use HasFactory;
+    use SoftDeletes;
     
     protected $fillable = [
         'title',

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -16,9 +16,23 @@
                         <a href="/posts/{{ $post->id }}">{{ $post->title }}</a>
                     </h2>
                     <p class='body'>{{ $post->body }}</p>
+                    <form action="/posts/{{ $post->id }}" id="form_{{ $post->id }}" method="post">
+                        @csrf
+                        @method('DELETE')
+                    <button type="button" onclick="deletePost({{ $post->id }})">delete</button>
+                    </form>
                 </div>
-            @endforeach
+            @endforeach 
         </div>
         <div class='paginate'>{{ $posts->links()}}</div>
+        <script>
+            function deletePost(id) {
+                'use strict'
+                
+                if(confirm('削除すると復元出来ません。\n本当に削除しますか？')) {
+                    document.getElementById(`form_${id}`).submit();
+                }
+            }
+        </script>
     </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,3 +19,4 @@ Route::get('/posts/{post}', [PostController::class,'show']);
 Route::post('/posts', [PostController::class, 'store']);
 Route::get('/posts/{post}/edit', [PostController::class, 'edit']);
 Route::put('/posts/{post}', [PostController::class, 'update']);
+Route::delete('/posts/{post}', [PostController::class, 'delete']);


### PR DESCRIPTION
投稿されたブログの削除deleteの追加を行った
・deleteのルーティング設定
・index.blade.phpの削除実行の導線追加のための修正(HTML ＋ JavaScript)
＊JavaScriptでの(`form_${id}`)の点々はシングルクォーテーションではなくバッククォートなので注意！！
・コントローラ実装
・論理削除のためのPostモデルクラス修正